### PR TITLE
Fixed build script syntax error occurring at line 58

### DIFF
--- a/build.py
+++ b/build.py
@@ -55,7 +55,7 @@ def main():
         else:
             print(f"Warning: File not found - {file_path}")
     destination = os.path.join(destination_directory, output_file_name)
-    compile_command = f"gcc -O3  {sys.argv[3] if avai == True else " "} {final_file} -o {destination}"
+    compile_command = f"gcc -O3  {sys.argv[3] if avai == True else ' '} {final_file} -o {destination}"
     print("Compiling the source files...")
     print(f"Command run: '{compile_command}'")
     print("\nCOMPILER MESSAGES IF ANY:")


### PR DESCRIPTION
Fixed syntax error on /build.py that occurs on line 58:
"compile_command = f"gcc -O3  {sys.argv[3] if avai == True else " "} {final_file} -o {destination}"                                                                                                     
SyntaxError: f-string: expecting '}'

changed code:
compile_command = f"gcc -O3 {sys.argv[3] if avai == True else ' '} {final_file} -o {destination}"
